### PR TITLE
Fix Android Gradle packaging of files with '.' prefix

### DIFF
--- a/scripts/android/files/build.gradle
+++ b/scripts/android/files/build.gradle
@@ -48,6 +48,9 @@ android {
 			shrinkResources = false
 		}
 	}
+	aaptOptions {
+		ignoreAssetsPattern = ''
+	}
 	packagingOptions {
 		doNotStrip '**/*.so'
 		jniLibs {


### PR DESCRIPTION
By default, Gradle ignores files prefixed with a dot. This caused a "Failed to unpack game assets, consider reinstalling the app" error on Android, because an entry for a file prefixed with a dot exists in `integrity.txt` but doesnt exist in the apk assets.

There is a dot prefix used in data/entity/binds. You can either rename it or merge my PR. Alternatively, should I open this PR against the main DDNet repository?

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
